### PR TITLE
Experimental/swift mailer php support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **org
 **swp
 db/**
+legacy/**
 resources/config**
 swapenv
 web

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,8 @@ RUN                     add-apt-repository ppa:ondrej/php && apt-get update
 RUN                     apt-get install php5.6
 RUN                     apt-get install php5.6-sqlite3
 RUN                     a2dismod php7.0 && a2enmod php5.6
+# DDT - remove!
+RUN                     echo "error_log = syslog" >> /etc/php/5.6/apache2/php.ini
 
 
 ### "web-server-configuration-and-launch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM                    ubuntu:14.04
+FROM                    ubuntu:16.04
 MAINTAINER              pr3d4t0r
 
 
@@ -39,7 +39,18 @@ RUN                     echo "postfix postfix/mailname string calendar.example.o
 
 
 ### "system-requirements"
-RUN                     apt-get install apache2 curl php5 postfix sqlite3 php5-sqlite unzip mailutils
+RUN                     apt-get install apache2
+RUN                     apt-get install curl
+RUN                     apt-get install postfix 
+RUN                     apt-get install mailutils
+RUN                     apt-get install rsyslog
+RUN                     apt-get install sqlite3
+RUN                     apt-get install php
+RUN                     apt-get install libapache2-mod-php
+RUN                     apt-get install php-sqlite3
+RUN                     apt-get install php-swiftmailer
+RUN                     apt-get install tree
+RUN                     apt-get install unzip
 
 
 ### "Baikal-installation"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,10 @@ RUN                     apt-get install rsyslog
 RUN                     apt-get install sqlite3
 RUN                     apt-get install php
 RUN                     apt-get install libapache2-mod-php
+RUN                     apt-get install php-date
+RUN                     apt-get install php-dom
+RUN                     apt-get install php-mbstring
 RUN                     apt-get install php-sqlite3
-# RUN                     apt-get install php-swiftmailer
 RUN                     apt-get install tree
 RUN                     apt-get install unzip
 
@@ -85,16 +87,7 @@ WORKDIR                 /etc/apache2/sites-available
 RUN                     /etc/init.d/apache2 stop ; a2enmod rewrite
 RUN                     mv -f 000-default.conf ..
 RUN                     ln -s /var/www/calendar_server/Specific/virtualhosts/baikal.apache2 000-default.conf
-
-### "php5_6"
-# Baikal 0.4.5 doesn't work with PHP 7.0 / Ubuntu
-RUN                     apt-get install software-properties-common
-RUN                     add-apt-repository ppa:ondrej/php && apt-get update
-RUN                     apt-get install php5.6
-RUN                     apt-get install php5.6-sqlite3
-RUN                     a2dismod php7.0 && a2enmod php5.6
-# DDT - remove!
-RUN                     echo "error_log = syslog" >> /etc/php/5.6/apache2/php.ini
+RUN                     echo "error_log = syslog" >> /etc/php/7.0/apache2/php.ini
 
 
 ### "web-server-configuration-and-launch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN                     apt-get install php-date
 RUN                     apt-get install php-dom
 RUN                     apt-get install php-mbstring
 RUN                     apt-get install php-sqlite3
-RUN                     apt-get install tree
 RUN                     apt-get install unzip
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN                     apt-get install sqlite3
 RUN                     apt-get install php
 RUN                     apt-get install libapache2-mod-php
 RUN                     apt-get install php-sqlite3
-RUN                     apt-get install php-swiftmailer
+# RUN                     apt-get install php-swiftmailer
 RUN                     apt-get install tree
 RUN                     apt-get install unzip
 
@@ -85,6 +85,14 @@ WORKDIR                 /etc/apache2/sites-available
 RUN                     /etc/init.d/apache2 stop ; a2enmod rewrite
 RUN                     mv -f 000-default.conf ..
 RUN                     ln -s /var/www/calendar_server/Specific/virtualhosts/baikal.apache2 000-default.conf
+
+### "php5_6"
+# Baikal 0.4.5 doesn't work with PHP 7.0 / Ubuntu
+RUN                     apt-get install software-properties-common
+RUN                     add-apt-repository ppa:ondrej/php && apt-get update
+RUN                     apt-get install php5.6
+RUN                     apt-get install php5.6-sqlite3
+RUN                     a2dismod php7.0 && a2enmod php5.6
 
 
 ### "web-server-configuration-and-launch"

--- a/bin/runapache2
+++ b/bin/runapache2
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-export APACHE_LOG_DIR="/var/log/apache2"
-export APACHE_LOCK_DIR="/var/lock/apache2"
-export APACHE_RUN_USER="www-data"
-export APACHE_RUN_GROUP="www-data"
-export APACHE_PID_FILE="/var/run/apache2/apache"
-export APACHE_RUN_DIR="/var/run/apache2"
-
 hostname calendar.example.org
 domainname example.org
+
+source /etc/apache2/envvars
+
+mkdir -p "$APACHE_LOCK_DIR"
+mkdir -p "$APACHE_RUN_DIR"
 
 service rsyslog start
 service postfix start


### PR DESCRIPTION
PHP 7 on Ubuntu 16.04 LTS; ready for future implementation of SwiftMailer.
