### PR TITLE
Refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,79 @@
-FROM                    ubuntu:16.04
-MAINTAINER              pr3d4t0r
+FROM ubuntu:16.04
 
-
-LABEL                   author="pr3d4t0r - Eugene Ciurana"
-LABEL                   copyright="(c) Copyright 2015, 2016 by CIME Software Ltd."
-LABEL                   description="Baikal / SabreDAV robust calendar and address book server with scheduling and email notifications"
-LABEL                   license="See: LICENSE.txt for complete licensing information."
-LABEL                   support="caldav AT cime.net"
-LABEL                   version="2.1"
-
-
-### "set-locale"
-RUN                     locale-gen en_US.UTF-8 && \
-                        update-locale LANG=en_US.UTF-8 && \
-                        update-locale LANGUAGE=en_US.UTF-8 && \
-                        update-locale LC_ALL=en_US.UTF-8
-
-ENV                     LANG en_US.UTF-8
-ENV                     LANGUAGE en_US:en
-ENV                     LC_ALL en_US.UTF-8
-ENV                     TERM=xterm
-
+LABEL author="pr3d4t0r - Eugene Ciurana"
+LABEL copyright="(c) Copyright 2015, 2016 by CIME Software Ltd."
+LABEL description="Baikal / SabreDAV robust calendar and address book server with scheduling and email notifications"
+LABEL license="See: LICENSE.txt for complete licensing information."
+LABEL support="caldav AT cime.net"
+LABEL version="2.1"
 
 ### "configure-apt"
-RUN                     echo "APT::Get::Assume-Yes true;" >> /etc/apt/apt.conf.d/80custom; \
-                        echo "APT::Get::Quiet true;" >> /etc/apt/apt.conf.d/80custom; \
-                        rm -Rvf /var/lib/apt/lists/*; \
-                        apt-get update
+RUN echo "APT::Get::Assume-Yes true;" >> /etc/apt/apt.conf.d/80custom \
+ && echo "APT::Get::Quiet true;" >> /etc/apt/apt.conf.d/80custom \
+ && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
 
+### Set some environment variables
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    TERM=xterm \
+    DEBIAN_FRONTEND=noninteractive
 
-### "configure-postfix"
+### Weird bug where this needs to be installed before the locales package
+RUN apt-get update && apt-get install -y --no-install-recommends --assume-yes apt-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    
+### Install the locales package first before the main set of packages    
+RUN apt-get update && apt-get install -y --no-install-recommends --assume-yes locales \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    
+### Generate the locales for the system
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+    && locale-gen en_US.UTF-8 \
+    && dpkg-reconfigure locales \
+    && update-locale LANG=en_US.UTF-8 \
+    && update-locale LANGUAGE=en_US.UTF-8 \
+    && update-locale LC_ALL=en_US.UTF-8
+
+### Configure Postfix options prior to installing the package to prevet the config screen from appearing
 #
 # These parameters are specific to your own Postfix relay!  Use your host and domain
 # names.
-RUN                     echo "postfix postfix/mailname string calendar.example.org" | debconf-set-selections && \
-                        echo "postfix postfix/main_mailer_type string 'Satellite system'" | debconf-set-selections && \
-                        echo "postfix postfix/relayhost string smtpcal.example.org" | debconf-set-selections && \
-                        echo "postfix postfix/root_address string cal-bounce@example.org" | debconf-set-selections
+RUN echo "postfix postfix/mailname string calendar.example.org" | debconf-set-selections && \
+    echo "postfix postfix/main_mailer_type string 'Satellite system'" | debconf-set-selections && \
+    echo "postfix postfix/relayhost string smtpcal.example.org" | debconf-set-selections && \
+    echo "postfix postfix/root_address string cal-bounce@example.org" | debconf-set-selections
 
-
-### "system-requirements"
-RUN                     apt-get install apache2
-RUN                     apt-get install curl
-RUN                     apt-get install postfix 
-RUN                     apt-get install mailutils
-RUN                     apt-get install rsyslog
-RUN                     apt-get install sqlite3
-RUN                     apt-get install php
-RUN                     apt-get install libapache2-mod-php
-RUN                     apt-get install php-date
-RUN                     apt-get install php-dom
-RUN                     apt-get install php-mbstring
-RUN                     apt-get install php-sqlite3
-RUN                     apt-get install unzip
-
+### Install the main set of system requirements
+RUN apt-get update && apt-get install -y \
+    apache2 \
+    curl \
+    postfix \
+    mailutils \ 
+    rsyslog \
+    sqlite3 \
+    php \
+    libapache2-mod-php \
+    php-date \
+    php-dom \
+    php-mbstring \
+    php-sqlite3 \
+    unzip \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ### "Baikal-installation"
-WORKDIR                 /var/www
-RUN                     curl -LO https://github.com/fruux/Baikal/releases/download/0.4.6/baikal-0.4.6.zip && unzip baikal-0.4.6.zip && rm -f baikal-0.4.6.zip
-RUN                     mv baikal calendar_server
-RUN                     rm -Rvf /var/www/calendar_server/Specific/db/.empty
+
+RUN cd /tmp/ && curl --silent -LO https://github.com/fruux/Baikal/releases/download/0.4.6/baikal-0.4.6.zip \
+ && unzip /tmp/baikal-0.4.6.zip -d /var/www/ \
+ && rm -Rvf /var/www/baikal/Specific/db/.empty && rm -f /tmp/baikal-0.4.6.zip 
 
 # Scheduling and email delivery.  See:
 # http://sabre.io/dav/scheduling/
 # https://groups.google.com/forum/#!searchin/sabredav-discuss/scheduling|sort:relevance/sabredav-discuss/CrGZXqw4sRw/vsHYq6FDcnkJ
 # This needs to be patched on the Baikal start up Server.php, NOT in the SabreDAV server.
-COPY                    resources/Server.php /var/www/calendar_server/Core/Frameworks/Baikal/Core/Server.php
-
-COPY                    resources/baikal.apache2 /var/www/calendar_server/Specific/virtualhosts/baikal.apache2
-COPY                    cal_infox.php /var/www/calendar_server/html/
+COPY resources/Server.php /var/www/baikal/Core/Frameworks/Baikal/Core/Server.php
+COPY resources/baikal.apache2 /var/www/baikal/Specific/virtualhosts/baikal.apache2
+COPY cal_infox.php /var/www/baikal/html/
 
 # The Baikal administration wizard creates these two config files when first run.  Preserve them
 # and save them to the resources/ directory.  These files must be preserved for upgrades.
@@ -76,27 +81,23 @@ COPY                    cal_infox.php /var/www/calendar_server/html/
 #
 # To use them:  uncomment these two lines and copy them to the Specific/ directory, per the
 # Baikal upgrade instructions at:  http://sabre.io/baikal/upgrade/
-# COPY                    resources/config.php /var/www/calendar_server/Specific/
-# COPY                    resources/config.system.php /var/www/calendar_server/Specific/
+# COPY resources/config.php /var/www/calendar_server/Specific/
+# COPY resources/config.system.php /var/www/calendar_server/Specific/
 
-
-WORKDIR                 /var/www/calendar_server
-RUN                     chown -Rf www-data:www-data Specific
-
-WORKDIR                 /etc/apache2/sites-available
-RUN                     /etc/init.d/apache2 stop ; a2enmod rewrite
-RUN                     mv -f 000-default.conf ..
-RUN                     ln -s /var/www/calendar_server/Specific/virtualhosts/baikal.apache2 000-default.conf
-RUN                     echo "error_log = syslog" >> /etc/php/7.0/apache2/php.ini
-
-
-### "web-server-configuration-and-launch"
-WORKDIR                 /
-COPY                    bin/runapache2 /
+RUN chown -Rf www-data:www-data /var/www/baikal/Specific \
+ && /etc/init.d/apache2 stop \
+ && a2enmod rewrite \
+ && rm /etc/apache2/sites-available/000-default.conf \
+ && rm /etc/apache2/sites-enabled/000-default.conf \
+ && cp /var/www/baikal/Specific/virtualhosts/baikal.apache2 /etc/apache2/sites-enabled/000-default.conf \
+ && echo "error_log = syslog" >> /etc/php/7.0/apache2/php.ini
 
 # httpoxy vulnerability fix:
-RUN                     awk '/vim: syntax/ { printf("# Poxy; CVE-2016-5387\nLoadModule headers_module /usr/lib/apache2/modules/mod_headers.so\nRequestHeader unset Proxy early\n%s\n", $0); next; } { print; }' /etc/apache2/apache2.conf > /tmp/apache2.conf
-RUN                     cat /tmp/apache2.conf > /etc/apache2/apache2.conf && rm /tmp/apache2.conf
+RUN awk '/vim: syntax/ { printf("# Poxy; CVE-2016-5387\nLoadModule headers_module /usr/lib/apache2/modules/mod_headers.so\nRequestHeader unset Proxy early\n%s\n", $0); next; } { print; }' /etc/apache2/apache2.conf > /tmp/apache2.conf
+RUN cat /tmp/apache2.conf > /etc/apache2/apache2.conf && rm /tmp/apache2.conf
 
-ENTRYPOINT                [ "/runapache2" ]
+### "web-server-configuration-and-launch"
+WORKDIR /
+COPY bin/runapache2 /
 
+ENTRYPOINT [ "/runapache2" ]


### PR DESCRIPTION
Tried to build this on multiple Linux and OS X systems, all were erroring out with 

``/bin/sh: 1: locale-gen: not found
returned a non-zero code: 127``

Encountered numerous other errors. Refactored it to be in line with Docker's recommendations and make it less prone to breaking. 

- Fixed locale generation as it was throwing a error causing the build to break

- MAINTAINER pr3d4t0r - Removed from Dockerfile as its now deprecated in favour of the author label 

- Refactored a lot of the Dockerfile to be in line with Dockerfile best practices so the image size is smaller ( https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices ) eg, moved most apt-get into a single RUN to keep them all in the same cache layer

- Set DEBIAN_FRONTEND=noninteractive to stop a few packages generating errors during install with needing a interactive console. 

- Fixed most of the "debconf: delaying package configuration, since apt-utils is not installed" message that was causing some packages to remain not configured.

- Fixed the error after a fresh build "apache2: Syntax error on line 219 of /etc/apache2/apache2.conf: Could not open configuration file /etc/apache2/sites-enabled/000-default.conf: No such file or directory" 

- Changed most relative paths to absolutes so the WORKDIR isn't constantly being shifted